### PR TITLE
Add placeholder api support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,10 @@ dependencies {
     compileOnly("com.github.LoneDev6:API-ItemsAdder:3.6.1")
     compileOnly("me.clip:placeholderapi:2.11.6")
 
+    depend = listOf("packetevents")
+    softDepend = listOf("ItemsAdder", "PlaceholderAPI")
+    name = "HologramLib"
+
     implementation("com.github.Tofaa2.EntityLib:spigot:2.4.11")
     implementation("net.kyori:adventure-text-minimessage:4.17.0")
     implementation("com.github.technicallycoded:FoliaLib:0.4.4")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,6 @@ bukkit {
     author = "MaximDe"
     foliaSupported = true
     depend = listOf("packetevents")
-    softDepend = listOf("ItemsAdder")
+    softDepend = listOf("ItemsAdder", "PlaceholderAPI")
     name = "HologramLib"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
     maven("https://oss.sonatype.org/content/groups/public/")
     maven("https://repo.codemc.io/repository/maven-releases/")
     maven("https://jitpack.io")
+    maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
 }
 
 dependencies {
@@ -30,6 +31,7 @@ dependencies {
     compileOnly("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
     compileOnly("com.github.retrooper:packetevents-spigot:2.8.0")
     compileOnly("com.github.LoneDev6:API-ItemsAdder:3.6.1")
+    compileOnly("me.clip:placeholderapi:2.11.6")
 
     implementation("com.github.Tofaa2.EntityLib:spigot:2.4.11")
     implementation("net.kyori:adventure-text-minimessage:4.17.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,10 +33,6 @@ dependencies {
     compileOnly("com.github.LoneDev6:API-ItemsAdder:3.6.1")
     compileOnly("me.clip:placeholderapi:2.11.6")
 
-    depend = listOf("packetevents")
-    softDepend = listOf("ItemsAdder", "PlaceholderAPI")
-    name = "HologramLib"
-
     implementation("com.github.Tofaa2.EntityLib:spigot:2.4.11")
     implementation("net.kyori:adventure-text-minimessage:4.17.0")
     implementation("com.github.technicallycoded:FoliaLib:0.4.4")

--- a/src/main/java/com/maximde/hologramlib/HologramLib.java
+++ b/src/main/java/com/maximde/hologramlib/HologramLib.java
@@ -6,6 +6,7 @@ import com.github.retrooper.packetevents.manager.player.PlayerManager;
 import com.maximde.hologramlib.bstats.Metrics;
 import com.maximde.hologramlib.hologram.HologramManager;
 import com.maximde.hologramlib.hologram.PassengerManager;
+import com.maximde.hologramlib.hook.PlaceholderAPIHook;
 import com.maximde.hologramlib.persistence.PersistenceManager;
 import com.maximde.hologramlib.utils.BukkitTasks;
 import com.maximde.hologramlib.utils.ItemsAdderHolder;
@@ -20,6 +21,8 @@ import me.tofaa.entitylib.EntityLib;
 import me.tofaa.entitylib.spigot.SpigotEntityLibPlatform;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandMap;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.lang.reflect.Field;
@@ -120,6 +123,16 @@ public abstract class HologramLib {
             persistenceManager = new PersistenceManager();
             hologramManager = new HologramManager(persistenceManager);
             persistenceManager.loadHolograms();
+
+            PluginManager pluginManager = Bukkit.getPluginManager();
+
+            Plugin placeholderAPIPlugin = pluginManager.getPlugin("PlaceholderAPI");
+            if (placeholderAPIPlugin != null && placeholderAPIPlugin.isEnabled()) {
+                plugin.getLogger().log(Level.INFO, "PlaceholderAPI found! Initializing hook...");
+                new PlaceholderAPIHook(PacketEvents.getAPI());
+            } else {
+                plugin.getLogger().log(Level.INFO, "PlaceholderAPI not found or not enabled. PlaceholderAPI support will be disabled.");
+            }
 
             AddonLib addonLib = new AddonLib((logLevel, message) -> Bukkit.getLogger().log(toJavaUtilLevel(logLevel), message), plugin.getDataFolder(), plugin.getDescription().getVersion());
             addonLib.setEnabledAddons(new String[]{"Commands"})

--- a/src/main/java/com/maximde/hologramlib/hook/PlaceholderAPIHook.java
+++ b/src/main/java/com/maximde/hologramlib/hook/PlaceholderAPIHook.java
@@ -1,0 +1,99 @@
+package com.maximde.hologramlib.hook;
+
+import com.github.retrooper.packetevents.PacketEventsAPI;
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
+import com.maximde.hologramlib.HologramLib;
+import com.maximde.hologramlib.hologram.Hologram;
+import com.maximde.hologramlib.hologram.TextHologram;
+import com.maximde.hologramlib.utils.MiniMessage;
+import me.clip.placeholderapi.PlaceholderAPI;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class PlaceholderAPIHook implements PacketListener {
+
+    private static final int TEXT_DISPLAY_TEXT_INDEX = 23; // The index for the message in the Entity Metadata packet (It worked on my side, tbh i dont feel like this is safe, but it works for now)
+
+    public PlaceholderAPIHook(PacketEventsAPI<?> packetEventsAPI) {
+        packetEventsAPI.getEventManager().registerListener(this, PacketListenerPriority.NORMAL);
+    }
+
+    @Override
+    public void onPacketSend(@NotNull PacketSendEvent event) {
+        if (event.getPacketType() != PacketType.Play.Server.ENTITY_METADATA) return;
+
+        WrapperPlayServerEntityMetadata packet = new WrapperPlayServerEntityMetadata(event);
+        int entityId = packet.getEntityId();
+
+        Optional<com.maximde.hologramlib.hologram.HologramManager> managerOpt = HologramLib.getManager();
+        if (managerOpt.isEmpty()) {
+            return;
+        }
+
+        Optional<Hologram<?>> hologramOptional = managerOpt.get().getHologramByEntityId(entityId);
+        if (hologramOptional.isEmpty()) {
+            return;
+        }
+
+        Hologram<?> hologram = hologramOptional.get();
+        if (!(hologram instanceof TextHologram textHologram)) {
+            return;
+        }
+
+        if (!textHologram.isPlaceholderApiEnabled()) {
+            return;
+        }
+
+        Player player = (Player) event.getPlayer();
+        if (player == null) {
+            return;
+        }
+
+        String rawText = textHologram.getRawText();
+        if (rawText == null || rawText.isEmpty()) {
+            return;
+        }
+
+        String parsedText = PlaceholderAPI.setPlaceholders(player, rawText);
+        Component finalComponent = MiniMessage.get(textHologram.replaceFontImages(parsedText));
+
+        List<EntityData<?>> newMetadata = new ArrayList<>();
+        boolean textMetaFound = false;
+
+        for (EntityData<?> data : packet.getEntityMetadata()) {
+            if (data.getIndex() == TEXT_DISPLAY_TEXT_INDEX &&
+                data.getType() == EntityDataTypes.ADV_COMPONENT) {
+
+                newMetadata.add(new EntityData<>(
+                    TEXT_DISPLAY_TEXT_INDEX,
+                    EntityDataTypes.ADV_COMPONENT,
+                    finalComponent
+                ));
+                textMetaFound = true;
+            } else {
+                newMetadata.add(data);
+            }
+        }
+
+        if (!textMetaFound) {
+            newMetadata.add(new EntityData<>(
+                TEXT_DISPLAY_TEXT_INDEX,
+                EntityDataTypes.ADV_COMPONENT,
+                finalComponent
+            ));
+        }
+
+        packet.setEntityMetadata(newMetadata);
+    }
+}


### PR DESCRIPTION
<img width="2558" height="1439" alt="image" src="https://github.com/user-attachments/assets/b1723bd1-a090-4e64-888f-277480b5b30d" />

```java
 TextHologram textHologram = new TextHologram("test_papi")
            .setMiniMessageText("Hello, %player_name%! Your world is <green>%player_world%</green>.")
            .setPlaceholderApiEnabled(true)
            .setAlignment(TextDisplay.TextAlignment.CENTER);
```

I don't know how stable it is, but I've tested a bit and everything works perfectly for me. Feel free to make / suggest changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integration with PlaceholderAPI, enabling dynamic placeholder replacement in hologram texts per player.
  * Introduced the ability to enable or disable PlaceholderAPI support for individual text holograms.
  * Added support for retrieving and managing holograms by their entity ID.

* **Bug Fixes**
  * Improved registration and removal logic to ensure holograms are consistently tracked and cleaned up.

* **Chores**
  * Updated build configuration to include PlaceholderAPI as a dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->